### PR TITLE
Qgis3

### DIFF
--- a/landscape_polygonoverlay.py
+++ b/landscape_polygonoverlay.py
@@ -157,7 +157,7 @@ class BatchConverter(object):
             #ints = self.BBoxIntersect(self.extent,f_coord)
             #if ints: # Bounding Box intersecting ?
             array = self.getClipArray(poly)
-            if array.__class__ != None.__class__: # Multi polygon or no raster values below ?
+            if array is not None: # Multi polygon or no raster values below ?
                 classes = sorted(numpy.unique(array)) # get classes
                 for val in (self.nodata,0):# Remove raster nodata value and zeros from class list
                     try:
@@ -165,7 +165,7 @@ class BatchConverter(object):
                     except ValueError:
                         pass
                 # Classified Methods -> Use landscape_statistics module
-                if cl.__class__ != None.__class__:
+                if cl is not None:
                     cl_analys = lcs.LandCoverAnalysis(array,cellsize,classes)
                     cl_array = numpy.copy(array) # new working array
                     cl_array[cl_array!=cl] = 0
@@ -260,7 +260,7 @@ class BatchConverter(object):
                 a = numpy.fromstring(i.tobytes(),'b')   
             except SystemError:
                 a = None
-        if a.__class__ != None.__class__:
+        if a is not None:
             a.shape=i.im.size[1], i.im.size[0]
         return a
 
@@ -362,7 +362,7 @@ class BatchConverter(object):
                 mask = self.imageToArray(rasterPoly)
 
             # Do the actual clipping
-            if mask.__class__ != None.__class__:
+            if mask is not None:
                 try:
                     clip2 = numpy.choose(mask,(clip, 0),mode='raise').astype(self.srcArray.dtype)
                 except Exception:

--- a/lecos_functions.py
+++ b/lecos_functions.py
@@ -427,15 +427,18 @@ def createRaster(output,cols,rows,array,nodata,gt,d='GTiff'):
     # flush data to disk, set the NoData value
     band.FlushCache()
     try:
-      band.SetNoDataValue(nodata)
+        band.SetNoDataValue(nodata)
     except TypeError:
-      band.SetNoDataValue(-9999) # set -9999 in the meantime
+        band.SetNoDataValue(-9999) # set -9999 in the meantime
 
     # georeference the image and set the projection
     tDs.SetGeoTransform(gt)
 
-    # Then set projection of current active layer
-    epsg = QgsProject.instance().defaultCrsForNewLayers().authid() #mapCanvas().mapRenderer().destinationCrs().srsid()
+    # Set projection of the current active layer or the project
+    if qgis.utils.iface.activeLayer():
+        epsg = qgis.utils.iface.activeLayer().crs().authid()
+    else:
+        epsg = QgsProject.instance().defaultCrsForNewLayers().authid() #mapCanvas().mapRenderer().destinationCrs().srsid()
     coord_system = osr.SpatialReference()    
     coord_system.ImportFromEPSG( int(re.findall('\d+', epsg)[0]) )
     tDs.SetProjection(coord_system.ExportToWkt())

--- a/lecos_sextantealgorithms.py
+++ b/lecos_sextantealgorithms.py
@@ -851,19 +851,20 @@ class RasterPolyOver(LandscapeVectorOverlayAlgorithm):
         
         # Create the output layer 
         title = ["PolygonFeatureID"]
+        fields = QgsFields()
+        fields.append(QgsField(title[0], QVariant.Int))
         for x in results:
-            title.append( str(x[0][1]) ) 
-        f = open(output, "wb" )
-        writer = csv.writer(f,delimiter=';',quotechar="'",quoting=csv.QUOTE_ALL)
-        writer.writerow(title)
+            fields.append(QgsField(str(x[0][1]), QVariant.Double, "", 20, 8))
+        sink, output = self.parameterAsSink(parameters, self.OUTPUT_FILE, context, fields, QgsWkbTypes.NoGeometry, QgsCoordinateReferenceSystem())
         # Get number of polygon features
         feat = list(range(0,len(results[0])))
         for feature in feat: # Write feature to new line
             r = [feature]
+            f = QgsFeature()
             for item in results:
-                r.append(item[feature][2])
-            writer.writerow(r)
-        f.close()        
+                r.append(float(item[feature][2]))
+            f.setAttributes(r)
+            sink.addFeature(f, QgsFeatureSink.FastInsert)        
         return {self.OUTPUT_FILE: output}
 
 
@@ -919,6 +920,8 @@ class GetRasterValuesPoint(LandscapeVectorOverlayAlgorithm):
         
         # Vector loading
         ds = ogr.Open(point)
+        if (not ds):
+            raise QgsProcessingException("Make sure Point layer is valid")
         lyr = ds.GetLayer()
         res = []
         for feat in lyr:
@@ -1015,7 +1018,6 @@ class VectorPolyOver(LandscapeVectorOverlayAlgorithm):
         whatL = self.m[self.parameterAsEnum(parameters, self.LMETRIC, context)]
         
         add2table = self.parameterAsBool(parameters, self.ADDTABLE, context)
-        output = self.parameterAsVectorLayer(parameters, self.OUTPUT_FILE, context)
             
         landlayer = Processing.getObject(inputFilename)
         #vectorlayer = Processing.getObject(vectorFilename)
@@ -1037,19 +1039,20 @@ class VectorPolyOver(LandscapeVectorOverlayAlgorithm):
         
         # Create the output layer 
         title = ["PolygonFeatureID"]
+        fields = QgsFields()
+        fields.append(QgsField(title[0], QVariant.Int))
         for x in results:
-            title.append( str(x[0][1]) ) 
-        f = open(output, "wb" )
-        writer = csv.writer(f,delimiter=';',quotechar="'",quoting=csv.QUOTE_ALL)
-        writer.writerow(title)
+            fields.append(QgsField(str(x[0][1]), QVariant.Double, "", 20, 8))
+        sink, output = self.parameterAsSink(parameters, self.OUTPUT_FILE, context, fields, QgsWkbTypes.NoGeometry, QgsCoordinateReferenceSystem())
         # Get number of polygon features
         feat = list(range(0,len(results[0])))
         for feature in feat: # Write feature to new line
             r = [feature]
+            f = QgsFeature()
             for item in results:
-                r.append(item[feature][2])
-            writer.writerow(r)
-        f.close()        
+                r.append(float(item[feature][2]))
+            f.setAttributes(r)
+            sink.addFeature(f, QgsFeatureSink.FastInsert)        
         return {self.OUTPUT_FILE: output}
 
 


### PR DESCRIPTION
Fixes based on [this comment](https://github.com/Martin-Jung/LecoS/issues/12#issuecomment-466536556) by @Martin-Jung .

> Hi @caiohamamura,
> 
> Great work.
> The GUI seems to work now as far as I can see. The nlmpy algorithms do work as well.
> I have not yet tested all algorithms, but found a number of other issues that did not happen before.
> 
> * [ ]  The query raster values tool returns an error that previously did not occur
> 
> ```
> /lecos_sextantealgorithms.py", line 922, in processAlgorithm
> lyr = ds.GetLayer()
> AttributeError: 'NoneType' object has no attribute 'GetLayer'
> ```
> * [ ]  The vector overlay returns an error for all algorithms. Probably wrong library connection or similar. Test it out with the data I supplied.
> 
> ```
> Processing algorithm…
> Algorithm 'Overlay raster metrics (Polygons)' starting…
> Input parameters:
> { 'ADDTABLE' : False, 'CMETRIC' : 1, 'IS_CLASS' : True, 'LAND_GRID' : 'TEST_Lecos.tif', 'LC_CLASS' : 11, 'LMETRIC' : 0, 'OUTPUT_FILE' : 'memory:', 'VECTOR_GRID' : 'test_center.shp' }
> 
> Traceback (most recent call last):
> File "/home/martin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LecoS/lecos_sextantealgorithms.py", line 856, in processAlgorithm
> f = open(output, "wb" )
> TypeError: expected str, bytes or os.PathLike object, not NoneType
> ```
> * [ ]  Something that I found somewhat annoying is that processing created raster files seem to ignore the project CRS, which did not happen before in QGIS 2. Do you happen to know how to query the currently set CRS and set it as default for all created files? At the moment raster files from the Landscape preparation NLMpy toolbox use WGS84 by default
