### PR TITLE
Fix TypeError for Python >= 3.10

### DIFF
--- a/lecos_dlg.py
+++ b/lecos_dlg.py
@@ -163,7 +163,7 @@ class LecosDialog(QDialog, Ui_Lecos):
                     func.DisplayError(self.iface,"LecoS: Warning" ,"The cells in the layer %s are not square. Calculated values will be incorrect" % (rasterName),"WARNING")
 
             self.sp_cellsize.setEnabled( True )
-            self.sp_cellsize.setValue( pixelSize )
+            self.sp_cellsize.setValue( round( pixelSize ) )
 
 
     # Save radio button


### PR DESCRIPTION
Fix `TypeError: setValue(self, int): argument 1 has unexpected type 'float'` for Python >= 3.10