### PR TITLE
Fixed CSV quotechar

### DIFF
--- a/lecos_functions.py
+++ b/lecos_functions.py
@@ -65,7 +65,7 @@ if hasattr(ogr,"RegisterAll"):
 # Save results to CSV
 def saveToCSV( results, titles, filePath ):
   f = open(filePath, "w", newline='')
-  writer = csv.writer(f,delimiter=';',quotechar="",quoting=csv.QUOTE_NONE)
+  writer = csv.writer(f,delimiter=';',quotechar='"',quoting=csv.QUOTE_NONE)
   writer.writerow(titles)
   for item in results:
     writer.writerow(item)


### PR DESCRIPTION
I fixed the (missing) quote character (quotechar) when creating a CSV .
The original code leads to

2023-05-16T13:08:37     WARNING    Traceback (most recent call last):
              File "/home/paolo/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LecoS/lecos_dlg.py", line 425, in accept
              func.saveToCSV(res,res_tit,dataPath)
              File "/home/paolo/.local/share/QGIS/QGIS3/profiles/default/python/plugins/LecoS/lecos_functions.py", line 68, in saveToCSV
              writer = csv.writer(f,delimiter=';',quotechar="",quoting=csv.QUOTE_NONE)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             TypeError: "quotechar" must be a 1-character string

and no CSV file is created.