### PR TITLE
fix: dead FRAGSTATS docs link

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -10,7 +10,7 @@ name=LecoS - Landscape Ecology Statistics
 qgisMinimumVersion=3.0
 description=Contains several analytical functions for land cover analysis
 version=3.0.0
-about=LecoS is based on metrics taken from FRAGSTATS: http://www.umass.edu/landeco/research/fragstats/fragstats.html Functions include the calculation of metrics on rasters and vector layers. A polygon overlay tool is also available to ease up computation. Additionally LecoS provides some functionalities to manipulate classified raster images.
+about=LecoS is based on metrics taken from FRAGSTATS: https://www.fragstats.org/ Functions include the calculation of metrics on rasters and vector layers. A polygon overlay tool is also available to ease up computation. Additionally LecoS provides some functionalities to manipulate classified raster images.
 
 ; Start of changelog file
 changelog =

--- a/sextante_info/patchstat.html
+++ b/sextante_info/patchstat.html
@@ -12,7 +12,7 @@
 
 <p><span id="section">Brief Description</span></p>
 
-<p> Allows the computation of patch metrics for a given land cover class. Look <a href="http://www.umass.edu/landeco/research/fragstats/documents/Metrics/Metrics%20TOC.htm">here</a> for an explanation of some of the metrics.</p>
+<p> Allows the computation of patch metrics for a given land cover class. Look <a href="https://www.fragstats.org/index.php/documentation">here</a> for an explanation of some of the metrics.</p>
 
 <p><span id="section">Parameters</span></p>
 <ul>

--- a/sextante_info/poloverlayraster.html
+++ b/sextante_info/poloverlayraster.html
@@ -13,7 +13,7 @@
 <p><span id="section">Brief Description</span></p>
 
 <p>	Overlays a raster with a given polygon vector layer and allows the user to compute a selected land cover metric per feature.<br> Ether landscape metrics <b>or</b> general statistics can be computed for every feature. Output results as table but can be added to the attribute table of the polygon vector layer as well.<br>
-Look <a href="http://www.umass.edu/landeco/research/fragstats/documents/Metrics/Metrics%20TOC.htm">here</a> for an explanation of some of the landscape metrics
+Look <a href="https://www.fragstats.org/index.php/documentation">here</a> for an explanation of some of the landscape metrics
 </p>
 
 <p><span id="section">Parameters</span></p>


### PR DESCRIPTION
Hello,
since last year, FRAGSTATS  is back in development and the site has moved to https://www.fragstats.org/. I fixed broken help links, now leads to the current metrics documentation.
Oto