### PR TITLE
Fix - numpy.int deprecated

### DIFF
--- a/landscape_modifier.py
+++ b/landscape_modifier.py
@@ -144,5 +144,5 @@ class LandscapeMod(object):
     # Remove smaller pixels in class raster
     def cleanRaster(self,n):
         s = ndimage.generate_binary_structure(2,1) # Taxicab struct
-        ras = ndimage.binary_opening(self.cl_array,s,iterations=n).astype(numpy.int)
+        ras = ndimage.binary_opening(self.cl_array,s,iterations=n).astype(numpy.int64)
         return(ras)

--- a/landscape_modifier.py
+++ b/landscape_modifier.py
@@ -144,5 +144,5 @@ class LandscapeMod(object):
     # Remove smaller pixels in class raster
     def cleanRaster(self,n):
         s = ndimage.generate_binary_structure(2,1) # Taxicab struct
-        ras = ndimage.binary_opening(self.cl_array,s,iterations=n).astype(numpy.int64)
+        ras = ndimage.binary_opening(self.cl_array,s,iterations=n).astype(int)
         return(ras)

--- a/landscape_statistics.py
+++ b/landscape_statistics.py
@@ -630,7 +630,7 @@ class LandCoverAnalysis(object):
 #         a = BatchConverter(rasterPath,landPath)
 #         print(a.go("LC_Sum",None))
 # 
-#         a = numpy.zeros((6,6), dtype=numpy.int) 
+#         a = numpy.zeros((6,6), dtype=numpy.int64)
 #         a[1:5, 1:5] = 1;a[3,3] = 0 ; a[2,2] = 2
 # 
 #         s = ndimage.generate_binary_structure(2,2) # Binary structure

--- a/landscape_statistics.py
+++ b/landscape_statistics.py
@@ -630,7 +630,7 @@ class LandCoverAnalysis(object):
 #         a = BatchConverter(rasterPath,landPath)
 #         print(a.go("LC_Sum",None))
 # 
-#         a = numpy.zeros((6,6), dtype=numpy.int64)
+#         a = numpy.zeros((6,6), dtype=int)
 #         a[1:5, 1:5] = 1;a[3,3] = 0 ; a[2,2] = 2
 # 
 #         s = ndimage.generate_binary_structure(2,2) # Binary structure


### PR DESCRIPTION
As `numpy.int` is [deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) in latest versions, changed it to `int`